### PR TITLE
mixins.collect: Exclude undefined values from returned Array

### DIFF
--- a/scripts/lateralus.mixins.js
+++ b/scripts/lateralus.mixins.js
@@ -241,6 +241,8 @@ define([
    * Execute any `{{#crossLink
    * "Lateralus.mixins/provide:property"}}{{/crossLink}}` handlers that have
    * been set up in the app and return an array of the returned values.
+   *
+   * Values that are `undefined` are excluded from the returned Array.
    * @method collect
    * @param {string} key The name of the `{{#crossLink
    * "Lateralus.mixins/provide:property"}}{{/crossLink}}` methods to run.
@@ -255,7 +257,9 @@ define([
     this.emit(PROVIDE_PREFIX + key,
         _.bind(collectedValues.push, collectedValues), args);
 
-    return collectedValues;
+    return _.reject(collectedValues, function (collectedValue) {
+      return collectedValue === undefined;
+    });
   };
 
   /**

--- a/test/spec/lateralus.js
+++ b/test/spec/lateralus.js
@@ -371,22 +371,48 @@ define([
               }
             });
 
-            var ExtendedComponent = Lateralus.Component.extend({
-              name: 'extended'
-              ,provide: {
-                test: function () {
-                  return 1;
+            it('Only returns defined values', function () {
+              var ExtendedComponent = Lateralus.Component.extend({
+                name: 'extended'
+                ,provide: {
+                  test: function () {
+                    return 1;
+                  }
                 }
-              }
+              });
+
+              var app = new App();
+              app.addComponent(ExtendedComponent);
+
+              var collectedTest = app.collect('test');
+              assert.deepEqual(collectedTest, [1]);
             });
 
-            var app = new App();
-            app.addComponent(ExtendedComponent);
+            it('Returns falsy values except for undefined', function () {
+              var ExtendedComponent1 = Lateralus.Component.extend({
+                name: 'extended-1'
+                ,provide: {
+                  test: function () {
+                    return false;
+                  }
+                }
+              });
 
-            var collectedTest = app.collect('test');
+              var ExtendedComponent2 = Lateralus.Component.extend({
+                name: 'extended-2'
+                ,provide: {
+                  test: function () {
+                    return 0;
+                  }
+                }
+              });
 
-            it('Only returns defined values', function () {
-              assert.deepEqual(collectedTest, [1]);
+              var app = new App();
+              app.addComponent(ExtendedComponent1);
+              app.addComponent(ExtendedComponent2);
+
+              var collectedTest = app.collect('test');
+              assert.deepEqual(collectedTest, [false, 0]);
             });
           });
         });

--- a/test/spec/lateralus.js
+++ b/test/spec/lateralus.js
@@ -359,6 +359,36 @@ define([
               assert.deepEqual(collectedTest, [5]);
             });
           });
+
+          describe('Returned array contains no undefined values', function () {
+            var App = getLateralusApp();
+
+            _.extend(App.prototype, {
+              provide: {
+                test: function () {
+                  return;
+                }
+              }
+            });
+
+            var ExtendedComponent = Lateralus.Component.extend({
+              name: 'extended'
+              ,provide: {
+                test: function () {
+                  return 1;
+                }
+              }
+            });
+
+            var app = new App();
+            app.addComponent(ExtendedComponent);
+
+            var collectedTest = app.collect('test');
+
+            it('Only returns defined values', function () {
+              assert.deepEqual(collectedTest, [1]);
+            });
+          });
         });
 
         describe('collectOne()', function () {


### PR DESCRIPTION
This modifies existing behavior, but should not actually impact any existing client code of Lateralus because it's a somewhat obscure use case.

I'm tagging a few folks on this for visibility, but I just want at least one LGTM or :+1: before merging.

@dancrumb @dispatchrabbi @jv-dan @jv-PintoBobcat @patrickdbakke @techn1cs 
