### PR TITLE
Bugfix/lateralus events inheritance

### DIFF
--- a/scripts/lateralus.mixins.js
+++ b/scripts/lateralus.mixins.js
@@ -192,6 +192,13 @@ define([
 
   mixins.setupProviders = function () {
     _.each(this.provide, function (fn, key) {
+      // The `provide` Object may have already been processed by setupProviders
+      // from a previous class instantiation (it is a shared prototype Object)
+      // so check for that and don't namespace the keys again.
+      if (key.match(PROVIDE_PREFIX)) {
+        return;
+      }
+
       this.provide[PROVIDE_PREFIX + key] = function (callback, args) {
         callback(fn.apply(this, args));
       };
@@ -376,7 +383,6 @@ define([
         } else {
           this.listenTo(subject, eventName, boundMethod);
         }
-
       }
     }, this);
 

--- a/scripts/lateralus.mixins.js
+++ b/scripts/lateralus.mixins.js
@@ -191,49 +191,12 @@ define([
   };
 
   mixins.setupProviders = function () {
-    /**
-     * A map of functions that will handle `{{#crossLink
-     * "Lateralus.mixins/collect"}}{{/crossLink}}` calls.  Each of the
-     * functions attached to this Object should return a value.  These
-     * functions **must** be completely synchronous.
-     *
-     *     var App = Lateralus.beget(function () {
-     *       Lateralus.apply(this, arguments);
-     *     });
-     *
-     *     _.extend(App.prototype, {
-     *       provide: {
-     *         demoData: function () {
-     *           return 1;
-     *         }
-     *       }
-     *     });
-     *
-     *     var app = new App();
-     *     var ComponentSubclass = Lateralus.Component.extend({
-     *       name: 'provider'
-     *       ,provide: {
-     *         demoData: function () {
-     *           return 2;
-     *         }
-     *       }
-     *     });
-     *
-     *     app.addComponent(ComponentSubclass);
-     *     console.log(app.collect('demoData')); // [1, 2]
-     * @property provide
-     * @type {Object|undefined}
-     */
-    if (!this.provide) {
-      return;
-    }
-
-    this.lateralusEvents = this.lateralusEvents || {};
-
     _.each(this.provide, function (fn, key) {
-      this.lateralusEvents[PROVIDE_PREFIX + key] = function (callback, args) {
+      this.provide[PROVIDE_PREFIX + key] = function (callback, args) {
         callback(fn.apply(this, args));
       };
+
+      delete this.provide[key];
     }, this);
   };
 
@@ -315,6 +278,41 @@ define([
          * @default undefined
          */
         lateralusEvents: this.lateralus || this
+
+        /**
+         * A map of functions that will handle `{{#crossLink
+         * "Lateralus.mixins/collect"}}{{/crossLink}}` calls.  Each of the
+         * functions attached to this Object should return a value.  These
+         * functions **must** be completely synchronous.
+         *
+         *     var App = Lateralus.beget(function () {
+         *       Lateralus.apply(this, arguments);
+         *     });
+         *
+         *     _.extend(App.prototype, {
+         *       provide: {
+         *         demoData: function () {
+         *           return 1;
+         *         }
+         *       }
+         *     });
+         *
+         *     var app = new App();
+         *     var ComponentSubclass = Lateralus.Component.extend({
+         *       name: 'provider'
+         *       ,provide: {
+         *         demoData: function () {
+         *           return 2;
+         *         }
+         *       }
+         *     });
+         *
+         *     app.addComponent(ComponentSubclass);
+         *     console.log(app.collect('demoData')); // [1, 2]
+         * @property provide
+         * @type {Object|undefined}
+         */
+        ,provide: this.lateralus || this
 
         /**
          * A map of functions or string references to functions that will

--- a/test/spec/lateralus.component.js
+++ b/test/spec/lateralus.component.js
@@ -45,31 +45,65 @@ define([
       describe('mixins', function () {
         describe('delegateLateralusEvents', function () {
           describe('Inheritance', function () {
-            var App = getLateralusApp();
-            var app = new App();
-            var testWasCalled = false;
-
-            var BaseComponent = Lateralus.Component.extend({
-              name: 'base'
-              ,lateralusEvents: {
-                test: function () {
-                  testWasCalled = true;
-                }
-              }
-            });
-
-            var ChildComponent = BaseComponent.extend({
-              name: 'child'
-              ,lateralusEvents: {
-                foo: _.noop
-              }
-            });
-
-            app.addComponent(ChildComponent);
-            app.emit('test');
-
-            it('Inherited the parent component\'s lateralusEvents map',
+            it('Inherits the parent component\'s lateralusEvents map',
                 function () {
+              var App = getLateralusApp();
+              var app = new App();
+              var testWasCalled = false;
+
+              var BaseComponent = Lateralus.Component.extend({
+                name: 'base'
+                ,lateralusEvents: {
+                  test: function () {
+                    testWasCalled = true;
+                  }
+                }
+              });
+
+              var ChildComponent = BaseComponent.extend({
+                name: 'child'
+                ,lateralusEvents: {
+                  foo: _.noop
+                }
+              });
+
+              app.addComponent(ChildComponent);
+              app.emit('test');
+
+              assert.isTrue(testWasCalled);
+            });
+
+            it('Inherits lateralusEvents from a parent component that also provides values',
+                function () {
+              var App = getLateralusApp();
+              var app = new App();
+              var testWasCalled = false;
+
+              var BaseComponent = Lateralus.Component.extend({
+                name: 'base'
+                ,lateralusEvents: {
+                  test: function () {
+                    testWasCalled = true;
+                  }
+                }
+
+                ,provide: {
+                  foo: function () {
+                    return true;
+                  }
+                }
+              });
+
+              var ChildComponent = BaseComponent.extend({
+                name: 'child'
+                ,lateralusEvents: {
+                  foo: _.noop
+                }
+              });
+
+              app.addComponent(ChildComponent);
+              app.emit('test');
+
               assert.isTrue(testWasCalled);
             });
           });

--- a/test/spec/lateralus.component.js
+++ b/test/spec/lateralus.component.js
@@ -88,7 +88,7 @@ define([
                 }
 
                 ,provide: {
-                  foo: function () {
+                  bar: function () {
                     return true;
                   }
                 }


### PR DESCRIPTION
This fixes an issue wherein `lateralusEvents` maps would not be inherited if a class also defined `provide`.

I'm fairly confident that this will fix the bug without negative effects, but I want to take some time when I get a chance to run this change through its paces with [Stylie](https://github.com/jeremyckahn/stylie) and [Mantra](https://github.com/jeremyckahn/mantra) before merging, as that is where I discovered the bug.

Tagging: @dancrumb @jv-dan @jv-PintoBobcat @techn1cs @patrickdbakke @dispatchrabbi 
