### PR TITLE
Implement Lateralus#shareWith

### DIFF
--- a/scripts/lateralus.js
+++ b/scripts/lateralus.js
@@ -213,6 +213,23 @@ define([
   };
 
   /**
+   * Relay `{{#crossLink "Lateralus.mixins/provide:property"}}{{/crossLink}}`d
+   * handlers to another `{{#crossLink "Lateralus"}}{{/crossLink}}` instance.
+   * This is the `{{#crossLink
+   * "Lateralus.mixins/provide:property"}}{{/crossLink}}` analog to
+   * `{{#crossLink "Lateralus.mixins/amplify"}}{{/crossLink}}`.
+   * @method shareWith
+   * @param {Lateralus} receiver The `{{#crossLink "Lateralus"}}{{/crossLink}}`
+   * instance to share `{{#crossLink
+   * "Lateralus.mixins/provide:property"}}{{/crossLink}}`d handlers with.
+   * @param {string} providerName The name of the `{{#crossLink
+   * "Lateralus.mixins/provide:property"}}{{/crossLink}}`er.
+   */
+  fn.shareWith = function (receiver, providerName) {
+    this.amplify(receiver, mixins.PROVIDE_PREFIX + providerName);
+  };
+
+  /**
    * Remove this `{{#crossLink "Lateralus"}}{{/crossLink}}` app from memory.
    * @method dispose
    */

--- a/scripts/lateralus.mixins.js
+++ b/scripts/lateralus.mixins.js
@@ -9,8 +9,6 @@ define([
 ) {
   'use strict';
 
-  var PROVIDE_PREFIX = '_provide:';
-
   /**
    * These method are mixed into `{{#crossLink "Lateralus"}}{{/crossLink}}`,
    * `{{#crossLink "Lateralus.Component"}}{{/crossLink}}`, and `{{#crossLink
@@ -19,6 +17,17 @@ define([
    * @requires http://backbonejs.org/#Events
    */
   var mixins = {};
+
+  /**
+   * Event namespace for `{{#crossLink
+   * "Lateralus.mixins/provide:property"}}{{/crossLink}}` handlers.
+   * @type {string}
+   * @property PROVIDE_PREFIX
+   * @final
+   * @private
+   */
+  mixins.PROVIDE_PREFIX = '_provide:';
+  var PROVIDE_PREFIX = mixins.PROVIDE_PREFIX;
 
   /**
    * @param {Object} obj

--- a/test/spec/lateralus.js
+++ b/test/spec/lateralus.js
@@ -154,6 +154,31 @@ define([
             assert.equal(app.toString(), 'lateralus');
           });
         });
+
+        describe('shareWith()', function () {
+          it('Relays the providers from another Lateralus app', function () {
+            var App1 = getLateralusApp();
+            var App2 = getLateralusApp();
+
+            _.extend(App1.prototype, {
+              provide: {
+                test: function () {
+                  return true;
+                }
+              }
+            });
+
+            var app1 = new App1();
+            var app2 = new App2();
+
+            app1.shareWith(app2, 'test');
+
+            var expected = true;
+            var actual = app2.collectOne('test');
+
+            assert.equal(expected, actual);
+          });
+        });
       });
 
       describe('Mixins', function () {


### PR DESCRIPTION
Adds `shareWith` convenience method.  An example of how this is handy: https://github.com/jeremyckahn/mantra/commit/1c75f5f7399345ea8817dbd76563a18c5eb6bd6d

@dancrumb @jv-dan @techn1cs @jv-PintoBobcat @dispatchrabbi @meltedspork, please review.
