### PR TITLE
generator: Alias lodash as underscore

### DIFF
--- a/generator-lateralus/app/templates/app/scripts/main.js
+++ b/generator-lateralus/app/templates/app/scripts/main.js
@@ -3,6 +3,11 @@
 
 require.config({
   baseUrl: '/'
+  ,map: {
+    '*': {
+      underscore: 'lodash'
+    }
+  }
   ,shim: {
     bootstrap: {
       deps: ['jquery']


### PR DESCRIPTION
Because it's Lodash.

Needed for sanity and Backbone.

@dispatchrabbi @dancrumb @techn1cs @jv-dan @jv-PintoBobcat 
